### PR TITLE
Reverted to standard raml-jsonschema-expander

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "nunjucks-markdown": "1.0.x",
     "q": "1.4.x",
     "raml2obj": "2.2.x",
-    "raml-jsonschema-expander": "mapscape/raml-jsonschema-expander"
+    "raml-jsonschema-expander": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "1.2.x",


### PR DESCRIPTION
Revert of raml-jsonschema-expander. This reverts non-standard changes to the raml-jsonchema-expander. The custom expander cannot deal with recursive json schemas.